### PR TITLE
WQP-1590, use new index on project_dim table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
         <wma.maven.url>https://artifactory.wma.usgs.gov/artifactory</wma.maven.url>
-        <wqp-etl-core.version>0.2.0</wqp-etl-core.version>
+        <wqp-etl-core.version>0.2.1-SNAPSHOT</wqp-etl-core.version>
     </properties>
 
     <ciManagement>


### PR DESCRIPTION
Previous work was done to add an index to the project_dim table -- see here:  
https://github.com/NWQMC/wqp-etl-core/pull/61

But, need to pick up this new index by pointing to the right version of wqp-etl-core in the pom.xml file.