### PR TITLE
WQP-1592 (Drop "unlogged" keyword from all WQP tables)

### DIFF
--- a/src/main/resources/db/changelog/epa/tables/activityConductingOrgAggregated/activityConductingOrgAggregated.sql
+++ b/src/main/resources/db/changelog/epa/tables/activityConductingOrgAggregated/activityConductingOrgAggregated.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.activity_conducting_org_aggregated
+create table if not exists ${WQX_SCHEMA_NAME}.activity_conducting_org_aggregated
 (act_uid                        numeric
 ,acorg_name_list                text
 )

--- a/src/main/resources/db/changelog/epa/tables/activityConductingOrgAggregated/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/activityConductingOrgAggregated/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.activity_conducting_org_aggregated"
+      id: "create.table.${WQX_SCHEMA_NAME}.activity_conducting_org_aggregated.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/activityMetricSum/activityMetricSum.sql
+++ b/src/main/resources/db/changelog/epa/tables/activityMetricSum/activityMetricSum.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.activity_metric_sum
+create table if not exists ${WQX_SCHEMA_NAME}.activity_metric_sum
 (act_uid                        numeric
 ,activity_metric_count          numeric
 )

--- a/src/main/resources/db/changelog/epa/tables/activityMetricSum/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/activityMetricSum/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.activity_metric_sum"
+      id: "create.table.${WQX_SCHEMA_NAME}.activity_metric_sum.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/activityProjectAggregated/activityProjectAggregated.sql
+++ b/src/main/resources/db/changelog/epa/tables/activityProjectAggregated/activityProjectAggregated.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.activity_project_aggregated
+create table if not exists ${WQX_SCHEMA_NAME}.activity_project_aggregated
 (act_uid                        numeric
 ,project_id_list                text
 ,project_name_list              text

--- a/src/main/resources/db/changelog/epa/tables/activityProjectAggregated/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/activityProjectAggregated/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.activity_project_aggregated"
+      id: "create.table.${WQX_SCHEMA_NAME}.activity_project_aggregated.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/analyticalMethodPlusNemi/analyticalMethodPlusNemi.sql
+++ b/src/main/resources/db/changelog/epa/tables/analyticalMethodPlusNemi/analyticalMethodPlusNemi.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.analytical_method_plus_nemi
+create table if not exists ${WQX_SCHEMA_NAME}.analytical_method_plus_nemi
 (anlmth_uid                     numeric
 ,anlmth_id                      character varying(20)
 ,amctx_cd                       character varying(30)

--- a/src/main/resources/db/changelog/epa/tables/analyticalMethodPlusNemi/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/analyticalMethodPlusNemi/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.analytical_method_plus_nemi"
+      id: "create.table.${WQX_SCHEMA_NAME}.analytical_method_plus_nemi.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/attachedObjectActivity/attachedObjectActivity.sql
+++ b/src/main/resources/db/changelog/epa/tables/attachedObjectActivity/attachedObjectActivity.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.attached_object_activity
+create table if not exists ${WQX_SCHEMA_NAME}.attached_object_activity
 (org_uid               numeric
 ,ref_uid               numeric
 ,activity_object_name  text

--- a/src/main/resources/db/changelog/epa/tables/attachedObjectActivity/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/attachedObjectActivity/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.attached_object_activity"
+      id: "create.table.${WQX_SCHEMA_NAME}.attached_object_activity.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/attachedObjectResult/attachedObjectResult.sql
+++ b/src/main/resources/db/changelog/epa/tables/attachedObjectResult/attachedObjectResult.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.attached_object_result
+create table if not exists ${WQX_SCHEMA_NAME}.attached_object_result
 (org_uid             numeric
 ,ref_uid             numeric
 ,result_object_name  text

--- a/src/main/resources/db/changelog/epa/tables/attachedObjectResult/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/attachedObjectResult/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.attached_object_result"
+      id: "create.table.${WQX_SCHEMA_NAME}.attached_object_result.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/detectionQuantLimit/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/detectionQuantLimit/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.detection_quant_limit"
+      id: "create.table.${WQX_SCHEMA_NAME}.detection_quant_limit.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/detectionQuantLimit/detectionQuantLimit.sql
+++ b/src/main/resources/db/changelog/epa/tables/detectionQuantLimit/detectionQuantLimit.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.detection_quant_limit
+create table if not exists ${WQX_SCHEMA_NAME}.detection_quant_limit
 (res_uid                        numeric
 ,rdqlmt_measure                 character varying(12)
 ,msunt_cd                       character varying(12)

--- a/src/main/resources/db/changelog/epa/tables/dqlHierarchy/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/dqlHierarchy/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.dql_hierarchy"
+      id: "create.table.${WQX_SCHEMA_NAME}.dql_hierarchy.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/dqlHierarchy/dqlHierarchy.sql
+++ b/src/main/resources/db/changelog/epa/tables/dqlHierarchy/dqlHierarchy.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.dql_hierarchy
+create table if not exists ${WQX_SCHEMA_NAME}.dql_hierarchy
 (hierarchy_value                numeric
 ,dqltyp_uid                     numeric
 ,dqltyp_name                    character varying(35)

--- a/src/main/resources/db/changelog/epa/tables/hrdatToSrid/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/hrdatToSrid/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.hrdat_to_srid"
+      id: "create.table.${WQX_SCHEMA_NAME}.hrdat_to_srid.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/hrdatToSrid/hrdatToSrid.sql
+++ b/src/main/resources/db/changelog/epa/tables/hrdatToSrid/hrdatToSrid.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.hrdat_to_srid
+create table if not exists ${WQX_SCHEMA_NAME}.hrdat_to_srid
 (hrdat_uid                      numeric
 ,srid                           integer
 )

--- a/src/main/resources/db/changelog/epa/tables/monitoringLocationLocal/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/monitoringLocationLocal/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.monitoring_location_local"
+      id: "create.table.${WQX_SCHEMA_NAME}.monitoring_location_local.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/monitoringLocationLocal/monitoringLocationLocal.sql
+++ b/src/main/resources/db/changelog/epa/tables/monitoringLocationLocal/monitoringLocationLocal.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.monitoring_location_local
+create table if not exists ${WQX_SCHEMA_NAME}.monitoring_location_local
 (monitoring_location_source     character varying (7)
 ,station_id                     numeric
 ,site_id                        text

--- a/src/main/resources/db/changelog/epa/tables/rDetectQntLmt/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/rDetectQntLmt/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.r_detect_qnt_lmt"
+      id: "create.table.${WQX_SCHEMA_NAME}.r_detect_qnt_lmt.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/rDetectQntLmt/rDetectQntLmt.sql
+++ b/src/main/resources/db/changelog/epa/tables/rDetectQntLmt/rDetectQntLmt.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.r_detect_qnt_lmt
+create table if not exists ${WQX_SCHEMA_NAME}.r_detect_qnt_lmt
 (res_uid                        numeric
 ,rdqlmt_uid                     numeric
 ,rdqlmt_measure                 character varying(12)

--- a/src/main/resources/db/changelog/epa/tables/resultFrequencyClassAggregated/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/resultFrequencyClassAggregated/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.result_frequency_class_aggregated"
+      id: "create.table.${WQX_SCHEMA_NAME}.result_frequency_class_aggregated.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/resultFrequencyClassAggregated/resultFrequencyClassAggregated.sql
+++ b/src/main/resources/db/changelog/epa/tables/resultFrequencyClassAggregated/resultFrequencyClassAggregated.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.result_frequency_class_aggregated
+create table if not exists ${WQX_SCHEMA_NAME}.result_frequency_class_aggregated
 (res_uid                        numeric
 ,frequency_class_code_1         text
 ,frequency_class_unit_1         text

--- a/src/main/resources/db/changelog/epa/tables/resultLabSamplePrepSum/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/resultLabSamplePrepSum/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.result_lab_sample_prep_sum"
+      id: "create.table.${WQX_SCHEMA_NAME}.result_lab_sample_prep_sum.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/resultLabSamplePrepSum/resultLabSamplePrepSum.sql
+++ b/src/main/resources/db/changelog/epa/tables/resultLabSamplePrepSum/resultLabSamplePrepSum.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.result_lab_sample_prep_sum
+create table if not exists ${WQX_SCHEMA_NAME}.result_lab_sample_prep_sum
 (res_uid                        numeric
 ,result_lab_sample_prep_count   numeric
 )

--- a/src/main/resources/db/changelog/epa/tables/resultTaxonFeedingGroupAggregated/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/resultTaxonFeedingGroupAggregated/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.result_taxon_feeding_group_aggregated"
+      id: "create.table.${WQX_SCHEMA_NAME}.result_taxon_feeding_group_aggregated.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/resultTaxonFeedingGroupAggregated/resultTaxonFeedingGroupAggregated.sql
+++ b/src/main/resources/db/changelog/epa/tables/resultTaxonFeedingGroupAggregated/resultTaxonFeedingGroupAggregated.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.result_taxon_feeding_group_aggregated
+create table if not exists ${WQX_SCHEMA_NAME}.result_taxon_feeding_group_aggregated
 (res_uid                        numeric
 ,feeding_group_list             text
 )

--- a/src/main/resources/db/changelog/epa/tables/resultTaxonHabitAggregated/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/resultTaxonHabitAggregated/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.result_taxon_habit_aggregated"
+      id: "create.table.${WQX_SCHEMA_NAME}.result_taxon_habit_aggregated.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/resultTaxonHabitAggregated/resultTaxonHabitAggregated.sql
+++ b/src/main/resources/db/changelog/epa/tables/resultTaxonHabitAggregated/resultTaxonHabitAggregated.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.result_taxon_habit_aggregated
+create table if not exists ${WQX_SCHEMA_NAME}.result_taxon_habit_aggregated
 (res_uid                        numeric
 ,habit_name_list                text
 )

--- a/src/main/resources/db/changelog/epa/tables/siteTypeConversion/changeLog.yml
+++ b/src/main/resources/db/changelog/epa/tables/siteTypeConversion/changeLog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
 
   - changeSet:
       author: drsteini
-      id: "create.table.${WQX_SCHEMA_NAME}.site_type_conversion"
+      id: "create.table.${WQX_SCHEMA_NAME}.site_type_conversion.v2"
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT

--- a/src/main/resources/db/changelog/epa/tables/siteTypeConversion/siteTypeConversion.sql
+++ b/src/main/resources/db/changelog/epa/tables/siteTypeConversion/siteTypeConversion.sql
@@ -1,4 +1,4 @@
-create unlogged table if not exists ${WQX_SCHEMA_NAME}.site_type_conversion
+create table if not exists ${WQX_SCHEMA_NAME}.site_type_conversion
 (mltyp_uid                      numeric
 ,mltyp_name                     character varying (45)
 ,station_group_type             character varying (256)


### PR DESCRIPTION
   Removed unlogged from create table sql scripts.
   Updated to version v2 for the create changeLog

The approach taken here is that, since wqx.* are regular tables
with no partitions, the setting of the table to logged can be done
separately using a single sql command on existing databases. Going
forward when the liquidbase is used to create the table, the table
will be in the desired state from the beginning.
No need to maintain a separate liquidbase script.